### PR TITLE
Heavily modified run_hyper and hyper tuning pipeline

### DIFF
--- a/hopwise/quick_start/__init__.py
+++ b/hopwise/quick_start/__init__.py
@@ -1,7 +1,6 @@
 from hopwise.quick_start.quick_start import (
     load_data_and_model,
     objective_function,
-    objective_function_optuna,
     run,
     run_hopwise,
     run_hopwises,

--- a/hopwise/quick_start/quick_start.py
+++ b/hopwise/quick_start/quick_start.py
@@ -233,7 +233,7 @@ def run_hopwises(rank, *args):
     )
 
 
-def objective_function(config_dict=None, config_file_list=None, saved=True):
+def objective_function(config_dict=None, config_file_list=None, saved=True, callback_fn=None):
     r"""The default objective_function used in HyperTuning
 
     Args:
@@ -241,7 +241,6 @@ def objective_function(config_dict=None, config_file_list=None, saved=True):
         config_file_list (list, optional): Config files used to modify experiment parameters. Defaults to ``None``.
         saved (bool, optional): Whether to save the model. Defaults to ``True``.
     """
-    from ray import tune
 
     config = Config(config_dict=config_dict, config_file_list=config_file_list)
     init_seed(config["seed"], config["reproducibility"])
@@ -256,60 +255,8 @@ def objective_function(config_dict=None, config_file_list=None, saved=True):
     model_name = config["model"]
     model = get_model(model_name)(config, train_data.dataset).to(config["device"])
     trainer = get_trainer(config["MODEL_TYPE"], config["model"])(config, model)
-    best_valid_score, best_valid_result = trainer.fit(train_data, valid_data, verbose=False, saved=saved)
-    test_result = trainer.evaluate(test_data, load_best_model=saved)
-
-    tune.report(**test_result)
-
-    return {
-        "model": model_name,
-        "best_valid_score": best_valid_score,
-        "valid_score_bigger": config["valid_metric_bigger"],
-        "best_valid_result": best_valid_result,
-        "test_result": test_result,
-    }
-
-
-def optuna_report(epoch_idx, valid_score, **kwargs):
-    r"""Report the intermediate value of the objective function.
-
-    Args:
-        valid_score (float): The intermediate value of the objective function.
-        epoch_idx (int): The epoch.
-    """
-    import optuna
-
-    trial = kwargs.get("trial")
-
-    trial.report(valid_score, epoch_idx)
-
-    # Handle pruning based on the intermediate value.
-    if trial.should_prune():
-        raise optuna.exceptions.TrialPruned()
-
-
-def objective_function_optuna(config=None, saved=True, trial=None):
-    r"""The default objective_function used in HyperTuning
-
-    Args:
-        config_dict (dict, optional): Parameters dictionary used to modify experiment parameters. Defaults to ``None``.
-        config_file_list (list, optional): Config files used to modify experiment parameters. Defaults to ``None``.
-        saved (bool, optional): Whether to save the model. Defaults to ``True``.
-    """
-    init_seed(config["seed"], config["reproducibility"])
-    logger = getLogger()
-    for hdlr in logger.handlers[:]:  # remove all old handlers
-        logger.removeHandler(hdlr)
-    init_logger(config)
-    logging.basicConfig(level=logging.ERROR)
-    dataset = create_dataset(config)
-    train_data, valid_data, test_data = data_preparation(config, dataset)
-    init_seed(config["seed"], config["reproducibility"])
-    model_name = config["model"]
-    model = get_model(model_name)(config, train_data._dataset).to(config["device"])
-    trainer = get_trainer(config["MODEL_TYPE"], config["model"])(config, model)
     best_valid_score, best_valid_result = trainer.fit(
-        train_data, valid_data, verbose=False, saved=saved, trial=trial, callback_fn=optuna_report
+        train_data, valid_data, verbose=False, saved=saved, callback_fn=callback_fn
     )
     if KnowledgeEvaluationType.REC in best_valid_result and KnowledgeEvaluationType.REC in best_valid_score:
         best_valid_score, best_valid_result = (
@@ -317,9 +264,6 @@ def objective_function_optuna(config=None, saved=True, trial=None):
             best_valid_result[KnowledgeEvaluationType.REC],
         )
     test_result = trainer.evaluate(test_data, load_best_model=saved)
-
-    for key, value in test_result.items():
-        trial.set_user_attr(key, value)
 
     return {
         "model": model_name,

--- a/hopwise/trainer/hyper_tuning.py
+++ b/hopwise/trainer/hyper_tuning.py
@@ -12,10 +12,15 @@
 ############################
 """
 
+import datetime
+import os
+from ast import literal_eval
+from enum import Enum
 from functools import partial
 
 import numpy as np
 
+from hopwise.config import Config
 from hopwise.utils.utils import dict2str
 
 
@@ -69,27 +74,6 @@ class ExhaustiveSearchError(Exception):
     r"""ExhaustiveSearchError"""
 
     pass
-
-
-def _validate_space_exhaustive_search(space):
-    from hyperopt.pyll.base import as_apply, dfs
-    from hyperopt.pyll.stochastic import implicit_stochastic_symbols
-
-    supported_stochastic_symbols = [
-        "randint",
-        "quniform",
-        "qloguniform",
-        "qnormal",
-        "qlognormal",
-        "categorical",
-    ]
-    for node in dfs(as_apply(space)):
-        if node.name in implicit_stochastic_symbols:
-            if node.name not in supported_stochastic_symbols:
-                raise ExhaustiveSearchError(
-                    "Exhaustive search is only possible with the following stochastic symbols: "
-                    "" + ", ".join(supported_stochastic_symbols)
-                )
 
 
 def exhaustive_search(new_ids, domain, trials, seed, nbMaxSucessiveFailures=1000):
@@ -149,29 +133,38 @@ def exhaustive_search(new_ids, domain, trials, seed, nbMaxSucessiveFailures=1000
 class HyperTuning:
     r"""HyperTuning Class is used to manage the parameter tuning process of recommender system models.
     Given objective funciton, parameters range and optimization algorithm, using HyperTuning can find
-    the best result among these parameters
+    the best result among these parameters.
 
     Note:
-        HyperTuning is based on the hyperopt (https://github.com/hyperopt/hyperopt)
+        HyperTuning provides three tuner tools:
+            - hyperopt (https://github.com/hyperopt/hyperopt)
+            - ray (https://docs.ray.io/en/latest/tune/index.html)
+            - optuna (https://optuna.org/)
 
         Thanks to sbrodeur for the exhaustive search code.
         https://github.com/hyperopt/hyperopt/issues/200
     """
 
     PARAMS_PER_ROW = 3
+    TUNER_TYPES = Enum("TUNER_TYPES", {"HYPEROPT": "hyperopt", "RAY": "ray", "OPTUNA": "optuna"})
 
     def __init__(
         self,
         objective_function,
+        tuner="optuna",
         space=None,
         params_file=None,
         params_dict=None,
         fixed_config_file_list=None,
         display_file=None,
-        algo="exhaustive",
+        algo=None,
         max_evals=100,
         early_stop=10,
+        output_path=None,
+        timeout=None,
+        study_name=None,
     ):
+        self.tuner = self.TUNER_TYPES[tuner.upper()]
         self.best_score = None
         self.best_params = None
         self.best_test_result = None
@@ -181,41 +174,182 @@ class HyperTuning:
 
         self.objective_function = objective_function
         self.max_evals = max_evals
+        self.timeout = timeout
         self.fixed_config_file_list = fixed_config_file_list
         self.display_file = display_file
+        self.output_path = output_path or "."
+        if not os.path.exists(self.output_path):
+            os.makedirs(self.output_path)
+        self.study_name = study_name or f"hyper_{datetime.now().strftime('%d_%m_%Y_%H_%M_%S')}"
+
         if space:
             self.space = space
         elif params_file:
-            self.space = self._build_space_from_file(params_file)
+            self.space = self.build_space_from_file(params_file)
         elif params_dict:
-            self.space = self._build_space_from_dict(params_dict)
+            self.space = self.build_space_from_dict(params_dict)
         else:
             raise ValueError("at least one of `space`, `params_file` and `params_dict` is provided")
-        if isinstance(algo, str):
-            if algo == "exhaustive":
+
+        self.select_algo(algo)
+        self.select_early_stop(early_stop)
+
+    def select_algo(self, algo):
+        r"""Select the algorithm for hyperparameter tuning
+        Args:
+            algo (str or callable): the algorithm name or function
+        """
+        if self.tuner == self.TUNER_TYPES.HYPEROPT:
+            if algo is None:
                 self.algo = partial(exhaustive_search, nbMaxSucessiveFailures=1000)
                 self.max_evals = _spacesize(self.space)
-            elif algo == "random":
-                from hyperopt import rand
+            elif isinstance(algo, str):
+                from hyperopt import anneal, rand, tpe
 
-                self.algo = rand.suggest
-            elif algo == "bayes":
-                from hyperopt import tpe
-
-                self.algo = tpe.suggest
+                if algo == "exhaustive":
+                    self.algo = partial(exhaustive_search, nbMaxSucessiveFailures=1000)
+                    self.max_evals = _spacesize(self.space)
+                elif algo == "random":
+                    self.algo = rand.suggest
+                elif algo == "bayes":
+                    self.algo = tpe.suggest
+                elif algo == "anneal":
+                    self.algo = anneal.suggest
+                else:
+                    raise ValueError(f"Illegal algo [{algo}]")
             else:
-                raise ValueError(f"Illegal algo [{algo}]")
-        else:
-            self.algo = algo
+                self.algo = algo
+        elif self.tuner == self.TUNER_TYPES.RAY:
+            from ray.tune import schedulers, search
+
+            if algo is None:
+                self.algo = {"search_alg": None, "scheduler": "async_hyperband"}
+            elif isinstance(algo, str):
+                if "-" in algo:
+                    search_alg, scheduler = algo.split("-")
+                    self.algo = {"search_alg": search_alg, "scheduler": scheduler}
+                else:
+                    search_alg = search_alg if hasattr(search, algo) else None
+                    scheduler = scheduler if hasattr(schedulers, algo) else None
+                    self.algo = {
+                        "search_alg": search_alg,
+                        "scheduler": scheduler,
+                    }
+        elif self.tuner == self.TUNER_TYPES.OPTUNA:
+            import optuna
+
+            if algo is None:
+                self.algo = {
+                    "sampler": None,
+                    "pruner": optuna.pruners.MedianPruner(),
+                }
+            elif isinstance(algo, str):
+                grid_space = {k: (v[2] if v[0] == "choice" else list(v[2:])) for k, v in self.space.items()}
+
+                if "-" in algo:
+                    sampler, pruner = algo.split("-")
+                    sampler_args = [grid_space] if sampler == "GridSampler" else []
+                    self.algo = {
+                        "sampler": getattr(optuna.samplers, sampler)(*sampler_args),
+                        "pruner": getattr(optuna.pruners, pruner)(),
+                    }
+                else:
+                    sampler = getattr(optuna.samplers, algo) if hasattr(optuna.samplers, algo) else None
+                    pruner = getattr(optuna.pruners, algo) if hasattr(optuna.pruners, algo) else None
+                    if sampler is not None and sampler is optuna.samplers.GridSampler:
+                        sampler_args = [grid_space]
+                    else:
+                        sampler_args = []
+                    self.algo = {
+                        "sampler": sampler(*sampler_args) if sampler is not None else None,
+                        "pruner": pruner() if pruner is not None else None,
+                    }
+
+    def select_early_stop(self, early_stop_steps):
         from hyperopt.early_stop import no_progress_loss
 
-        self.early_stop_fn = no_progress_loss(early_stop)
+        self.early_stop_fn = no_progress_loss(early_stop_steps)
+
+    def _get_tuner_distributions(self):
+        if self.tuner == self.TUNER_TYPES.HYPEROPT:
+            from hyperopt import hp
+
+            def choice(name, values):
+                return hp.choice(name, values)
+
+            def uniform(name, low, high):
+                return hp.uniform(name, low, high)
+
+            def quniform(name, low, high, q):
+                return hp.quniform(name, low, high, q)
+
+            def loguniform(name, low, high):
+                return hp.loguniform(name, low, high)
+        elif self.tuner == self.TUNER_TYPES.RAY:
+            from ray import tune
+
+            def choice(name, values):
+                return tune.choice(values)
+
+            def uniform(name, low, high):
+                return tune.uniform(low, high)
+
+            def quniform(name, low, high, q):
+                return tune.quniform(low, high, q)
+
+            def loguniform(name, low, high):
+                return tune.loguniform(low, high)
+        elif self.tuner == self.TUNER_TYPES.OPTUNA:
+
+            def choice(name, values):
+                return "choice", name, values
+
+            def uniform(name, low, high):
+                return "uniform", name, low, high
+
+            def quniform(name, low, high, q):
+                return "quniform", name, low, high, q
+
+            def loguniform(name, low, high):
+                return "loguniform", name, low, high
+
+        return choice, uniform, quniform, loguniform
+
+    def build_space_from_file(self, file):
+        choice, uniform, quniform, loguniform = self._get_tuner_distributions()
+
+        space = self._build_space_from_file(
+            file,
+            choice_fn=choice,
+            uniform_fn=uniform,
+            quniform_fn=quniform,
+            loguniform_fn=loguniform,
+        )
+
+        return space
+
+    def build_space_from_dict(self, config_dict):
+        choice, uniform, quniform, loguniform = self._get_tuner_distributions()
+
+        space = self._build_space_from_dict(
+            config_dict,
+            choice_fn=choice,
+            uniform_fn=uniform,
+            quniform_fn=quniform,
+            loguniform_fn=loguniform,
+        )
+
+        return space
 
     @staticmethod
-    def _build_space_from_file(file):
-        from hyperopt import hp
-
-        space = {}
+    def _build_space_from_file(
+        file,
+        choice_fn=None,
+        uniform_fn=None,
+        quniform_fn=None,
+        loguniform_fn=None,
+    ):
+        config_dict = {}
         with open(file) as fp:
             for line in fp:
                 para_list = line.strip().split(" ")
@@ -227,53 +361,99 @@ class HyperTuning:
                     "".join(para_list[2:]),
                 )
                 if para_type == "choice":
-                    para_value = eval(para_value)
-                    space[para_name] = hp.choice(para_name, para_value)
+                    config_dict.setdefault("choice", {})
+                    config_dict["choice"][para_name] = literal_eval(para_value)
                 elif para_type == "uniform":
+                    config_dict.setdefault("uniform", {})
                     low, high = para_value.strip().split(",")
-                    space[para_name] = hp.uniform(para_name, float(low), float(high))
+                    config_dict["uniform"][para_name] = (float(low), float(high))
                 elif para_type == "quniform":
+                    config_dict.setdefault("quniform", {})
                     low, high, q = para_value.strip().split(",")
-                    space[para_name] = hp.quniform(para_name, float(low), float(high), float(q))
+                    config_dict["quniform"][para_name] = (float(low), float(high), float(q))
                 elif para_type == "loguniform":
+                    config_dict.setdefault("loguniform", {})
                     low, high = para_value.strip().split(",")
-                    space[para_name] = hp.loguniform(para_name, float(low), float(high))
+                    config_dict["loguniform"][para_name] = (float(low), float(high))
                 else:
                     raise ValueError(f"Illegal param type [{para_type}]")
+
+        space = HyperTuning._build_space_from_dict(
+            config_dict,
+            choice_fn=choice_fn,
+            uniform_fn=uniform_fn,
+            quniform_fn=quniform_fn,
+            loguniform_fn=loguniform_fn,
+        )
         return space
 
     @staticmethod
-    def _build_space_from_dict(config_dict):
-        from hyperopt import hp
-
+    def _build_space_from_dict(
+        config_dict,
+        choice_fn=None,
+        uniform_fn=None,
+        quniform_fn=None,
+        loguniform_fn=None,
+    ):
         space = {}
         for para_type in config_dict:
             if para_type == "choice":
                 for para_name in config_dict["choice"]:
                     para_value = config_dict["choice"][para_name]
-                    space[para_name] = hp.choice(para_name, para_value)
+                    space[para_name] = choice_fn(para_name, para_value)
             elif para_type == "uniform":
                 for para_name in config_dict["uniform"]:
                     para_value = config_dict["uniform"][para_name]
                     low = para_value[0]
                     high = para_value[1]
-                    space[para_name] = hp.uniform(para_name, float(low), float(high))
+                    space[para_name] = uniform_fn(para_name, float(low), float(high))
             elif para_type == "quniform":
                 for para_name in config_dict["quniform"]:
                     para_value = config_dict["quniform"][para_name]
                     low = para_value[0]
                     high = para_value[1]
                     q = para_value[2]
-                    space[para_name] = hp.quniform(para_name, float(low), float(high), float(q))
+                    space[para_name] = quniform_fn(para_name, float(low), float(high), float(q))
             elif para_type == "loguniform":
                 for para_name in config_dict["loguniform"]:
                     para_value = config_dict["loguniform"][para_name]
                     low = para_value[0]
                     high = para_value[1]
-                    space[para_name] = hp.loguniform(para_name, float(low), float(high))
+                    space[para_name] = loguniform_fn(para_name, float(low), float(high))
             else:
                 raise ValueError(f"Illegal param type [{para_type}]")
         return space
+
+    def build_optuna_space(self, trial):
+        r"""Build the space for optuna
+
+        Args:
+            trial (optuna.trial): the trial object
+        """
+
+        params = {}
+        for para_name in self.space:
+            para_type, _, *para_value = self.space[para_name]
+            if para_type == "choice":
+                para_value = para_value[0]
+                params[para_name] = trial.suggest_categorical(para_name, para_value)
+            elif para_type == "uniform":
+                low = para_value[0]
+                high = para_value[1]
+                params[para_name] = trial.suggest_float(para_name, low, high)
+            elif para_type == "quniform":
+                low = para_value[0]
+                high = para_value[1]
+                q = para_value[2]
+                params[para_name] = trial.suggest_float(para_name, low, high, step=q)
+            elif para_type == "loguniform":
+                low = para_value[0]
+                high = para_value[1]
+                params[para_name] = trial.suggest_float(para_name, np.exp(low), np.exp(high), log=True)
+            else:
+                raise ValueError(f"  Illegal param type [{para_type}]")
+
+        return params
 
     @staticmethod
     def params2str(params):
@@ -298,13 +478,16 @@ class HyperTuning:
         print(result_dict["test_result"])
         print()
 
-    def export_result(self, output_file=None):
+    def export_result(self, output_path=None):
         r"""Write the searched parameters and corresponding results to the file
 
         Args:
-            output_file (str): the output file
+            output_path (str): the output file
 
         """
+        output_path = output_path or self.output_path
+        output_file = os.path.join(output_path, self.study_name + ".txt")
+
         with open(output_file, "w") as fp:
             for params in self.params2result:
                 fp.write(params + "\n")
@@ -312,14 +495,20 @@ class HyperTuning:
 
                 fp.write("Test result:\n" + dict2str(self.params2result[params]["test_result"]) + "\n\n")
 
+                if self.tuner == "optuna":
+                    if not hasattr(self, "study"):
+                        raise ValueError("Optuna study not created. Call `run` method first.")
+
+                    optuna_df = self.study.trials_dataframe()
+                    fp.write("Optuna trials dataframe:\n")
+                    optuna_df.to_string(fp, index=False)
+
     def trial(self, params):
         r"""Given a set of parameters, return results and optimization status
 
         Args:
             params (dict): the parameter dictionary
         """
-        import hyperopt
-
         config_dict = params.copy()
         params_str = self.params2str(params)
         self.params_list.append(params_str)
@@ -334,23 +523,15 @@ class HyperTuning:
         self.model = model
         self.score_list.append(score)
 
-        if not self.best_score:
-            self.best_score = score
-            self.best_params = params
-            self._print_result(result_dict)
-        elif bigger:
-            if score > self.best_score:
-                self.best_score = score
-                self.best_params = params
-                self._print_result(result_dict)
-        elif score < self.best_score:
+        if not self.best_score or (bigger and score > self.best_score) or (not bigger and score < self.best_score):
             self.best_score = score
             self.best_params = params
             self._print_result(result_dict)
 
         if bigger:
             score = -score
-        return {"loss": score, "status": hyperopt.STATUS_OK}
+
+        return {**result_dict, "hyper_score": score}
 
     def plot_hyper(self):
         import pandas as pd
@@ -385,14 +566,109 @@ class HyperTuning:
 
     def run(self):
         r"""Begin to search the best parameters"""
-        from hyperopt import fmin
+        if self.tuner == self.TUNER_TYPES.HYPEROPT:
+            import hyperopt
 
-        fmin(
-            self.trial,
-            self.space,
-            algo=self.algo,
-            max_evals=self.max_evals,
-            early_stop_fn=self.early_stop_fn,
-        )
+            def hyperopt_objective(params):
+                try:
+                    result_dict = self.trial(params)
+                except Exception as e:
+                    print(f"Error occurred during trial: {e}")
+                    import traceback
+
+                    traceback.print_exc()
+                    return {"loss": np.nan, "status": hyperopt.STATUS_FAIL}
+
+                return {"loss": result_dict["hyper_score"], "status": hyperopt.STATUS_OK}
+
+            hyperopt.fmin(
+                hyperopt_objective,
+                self.space,
+                algo=self.algo,
+                max_evals=self.max_evals,
+                early_stop_fn=self.early_stop_fn,
+                timeout=self.timeout,
+                trials_save_file=os.path.join(self.output_path, self.study_name),
+            )
+        elif self.tuner == self.TUNER_TYPES.RAY:
+            import ray
+            from ray import tune
+
+            def ray_objective(params):
+                result_dict = self.trial(params)
+                tune.report(result_dict["test_result"])
+
+                return result_dict
+
+            fixed_config = Config(config_file_list=self.fixed_config_file_list)
+            valid_metric = fixed_config["valid_metric"]
+
+            ray.init()
+            tune.register_trainable("ray-trial", ray_objective)
+            if self.algo["scheduler"] is not None:
+                scheduler = tune.create_scheduler(
+                    self.algo["scheduler"],
+                    metric=valid_metric,
+                    mode="min",
+                    max_t=self.max_evals,
+                    grace_period=1,
+                    reduction_factor=2,
+                )
+
+            tune.run(
+                ray_objective,
+                config=self.space,
+                num_samples=self.max_evals,
+                scheduler=scheduler,
+                search_alg=self.algo["search_alg"],
+                local_dir=self.output_path,
+                name=self.study_name,
+                log_to_file=self.study_name,
+            )
+        elif self.tuner == self.TUNER_TYPES.OPTUNA:
+            import optuna
+
+            self.study = optuna.create_study(
+                direction="minimize",
+                study_name=self.study_name,
+                storage=f"sqlite:///{os.path.join(self.output_path, self.study_name)}.db",
+                pruner=self.algo["pruner"],
+                sampler=self.algo["sampler"],
+            )
+
+            update_objective_function = True
+
+            def optuna_objective(trial):
+                nonlocal update_objective_function
+
+                params = self.build_optuna_space(trial)
+
+                def trial_callback(epoch_idx, valid_score):
+                    trial.report(valid_score, epoch_idx)
+
+                    if trial.should_prune():
+                        raise optuna.exceptions.TrialPruned()
+
+                if update_objective_function:
+                    self.objective_function = partial(
+                        self.objective_function,
+                        callback_fn=trial_callback,
+                    )
+
+                    update_objective_function = False
+
+                result_dict = self.trial(params)
+
+                for key, value in result_dict["test_result"].items():
+                    trial.set_user_attr(key, value)
+
+                return result_dict["hyper_score"]
+
+            self.study.optimize(
+                optuna_objective,
+                n_trials=self.max_evals,
+                timeout=self.timeout,
+            )
+
         if self.display_file is not None:
             self.plot_hyper()

--- a/hopwise/trainer/trainer.py
+++ b/hopwise/trainer/trainer.py
@@ -372,9 +372,7 @@ class Trainer(AbstractTrainer):
 
         self.tensorboard.add_hparams(hparam_dict, {"hparam/best_valid_result": best_valid_result})
 
-    def fit(
-        self, train_data, valid_data=None, verbose=True, saved=True, show_progress=False, callback_fn=None, trial=None
-    ):
+    def fit(self, train_data, valid_data=None, verbose=True, saved=True, show_progress=False, callback_fn=None):
         r"""Train the model based on the train data and the valid data.
 
         Args:
@@ -458,7 +456,7 @@ class Trainer(AbstractTrainer):
                     self.best_valid_result = valid_result
 
                 if callback_fn:
-                    callback_fn(epoch_idx, valid_score, trial=trial)
+                    callback_fn(epoch_idx, valid_score)
 
                 if stop_flag:
                     stop_output = "Finished training, best eval result in epoch %d" % (
@@ -859,9 +857,7 @@ class KGTrainer(Trainer):
         self.wandblogger.log_eval_metrics(result, head="eval")
         return result
 
-    def fit(
-        self, train_data, valid_data=None, verbose=True, saved=True, show_progress=False, callback_fn=None, trial=None
-    ):
+    def fit(self, train_data, valid_data=None, verbose=True, saved=True, show_progress=False, callback_fn=None):
         r"""Train the model based on the train data and the valid data.
 
         Args:
@@ -980,7 +976,7 @@ class KGTrainer(Trainer):
                         self.best_valid_result = valid_result
 
                     if callback_fn:
-                        callback_fn(epoch_idx, valid_score, trial=trial)
+                        callback_fn(epoch_idx, valid_score)
 
                     if task == KnowledgeEvaluationType.REC and stop_flag:
                         stop_output = "Finished training, best eval result in epoch %d" % (

--- a/run_hyper.py
+++ b/run_hyper.py
@@ -8,167 +8,64 @@
 # @Email  : linzihan.super@foxmail.com, houyupeng@ruc.edu.cn, zgw15630559577@163.com, zxcptss@gmail.com
 
 import argparse
-import math
-import os
 from datetime import datetime
 
-import optuna
-import ray
-from optuna.trial import TrialState
-from ray import tune
-from ray.tune.schedulers import ASHAScheduler
-
-from hopwise.config import Config
-from hopwise.quick_start import objective_function, objective_function_optuna
+from hopwise.quick_start import objective_function
 from hopwise.trainer import HyperTuning
 
 
-def hyperopt_tune(args):
-    # plz set algo='exhaustive' to use exhaustive search, in this case, max_evals is auto set
+def tune(args):
+    # plz set algo='exhaustive' to use exhaustive search with hyperopt, in this case, max_evals is auto set
     # in other case, max_evals needs to be set manually
-    config_file_list = args.config_files.strip().split(" ") if args.config_files else None
-    hp = HyperTuning(
+    ht = HyperTuning(
         objective_function,
-        algo="exhaustive",
+        tuner=args.tool,
+        algo=args.algo,
         early_stop=10,
-        max_evals=100,
+        max_evals=args.max_evals,
         params_file=args.params_file,
         fixed_config_file_list=config_file_list,
         display_file=args.display_file,
+        output_path=args.output_path,
+        study_name=args.study_name,
     )
-    hp.run()
-    hp.export_result(output_file=args.output_file)
-    print("best params: ", hp.best_params)
+    ht.run()
+    ht.export_result(output_path=args.output_path)
+    print("best params: ", ht.best_params)
     print("best result: ")
-    print(hp.params2result[hp.params2str(hp.best_params)])
-
-
-def ray_tune(args):
-    config_file_list = args.config_files.strip().split(" ") if args.config_files else None
-    config_file_list = [os.path.join(os.getcwd(), file) for file in config_file_list] if args.config_files else None
-    params_file = os.path.join(os.getcwd(), args.params_file) if args.params_file else None
-    ray.init(address="auto")
-    tune.register_trainable("train_func", objective_function)
-    config = {}
-    with open(params_file) as fp:
-        for line in fp:
-            para_list = line.strip().split(" ")
-            if len(para_list) < 3:
-                continue
-            para_name, para_type, para_value = (
-                para_list[0],
-                para_list[1],
-                "".join(para_list[2:]),
-            )
-            if para_type == "choice":
-                para_value = eval(para_value)
-                config[para_name] = tune.choice(para_value)
-            elif para_type == "uniform":
-                low, high = para_value.strip().split(",")
-                config[para_name] = tune.uniform(float(low), float(high))
-            elif para_type == "quniform":
-                low, high, q = para_value.strip().split(",")
-                config[para_name] = tune.quniform(float(low), float(high), float(q))
-            elif para_type == "loguniform":
-                low, high = para_value.strip().split(",")
-                config[para_name] = tune.loguniform(math.exp(float(low)), math.exp(float(high)))
-            else:
-                raise ValueError(f"Illegal param type [{para_type}]")
-    # choose different schedulers to use different tuning optimization algorithms
-    # For details, please refer to Ray's official website https://docs.ray.io
-    scheduler = ASHAScheduler(metric="recall@10", mode="max", max_t=10, grace_period=1, reduction_factor=2)
-
-    local_dir = "./ray_log"
-    result = tune.run(
-        tune.with_parameters(objective_function, config_file_list=config_file_list),
-        config=config,
-        num_samples=5,
-        log_to_file=args.output_file,
-        scheduler=scheduler,
-        local_dir=local_dir,
-        resources_per_trial={"gpu": 0},
-    )
-
-    best_trial = result.get_best_trial("ndcg@10", "max", "last")
-    print("best params: ", best_trial.config)
-    print("best result: ", best_trial.last_result)
-
-
-def optuna_tune(args):
-    config_file_list = args.config_files.strip().split(" ") if args.config_files else None
-    config = {}
-    config = Config(config_dict={}, config_file_list=config_file_list)
-
-    def objective(trial):
-        with open(args.params_file) as fp:
-            for line in fp:
-                para_list = line.strip().split(" ")
-                if len(para_list) < 3:
-                    continue
-                para_name, para_type, para_value = (
-                    para_list[0],
-                    para_list[1],
-                    "".join(para_list[2:]),
-                )
-                if para_type == "choice":
-                    para_value = eval(para_value)
-                    config[para_name] = trial.suggest_categorical(para_name, para_value)
-                elif para_type == "uniform":
-                    low, high = map(float, para_value.strip().split(","))
-                    config[para_name] = trial.suggest_float(para_name, low, high)
-                elif para_type == "loguniform":
-                    low, high = map(float, para_value.strip().split(","))
-                    config[para_name] = trial.suggest_loguniform(para_name, low, high)
-                elif para_type == "quniform":
-                    low, high, q = map(float, para_value.strip().split(","))
-                    config[para_name] = trial.suggest_float(para_name, low, high, step=q)
-                else:
-                    raise ValueError(f"Illegal param type [{para_type}]")
-        # Call the objective function with the suggested configuration
-        result = objective_function_optuna(config=config, trial=trial)
-        return result["best_valid_score"]
-
-    study = optuna.create_study(direction="maximize", study_name=args.study_name)
-    study.optimize(objective, n_trials=args.trials)
-
-    complete_trials = study.get_trials(deepcopy=False, states=[TrialState.COMPLETE])
-    pruned_trials = study.get_trials(deepcopy=False, states=[TrialState.PRUNED])
-
-    print("Number of finished trials: ", len(study.trials))
-    print("Number of complete trials: ", len(complete_trials))
-    print("Number of pruned trials: ", len(pruned_trials))
-    print("Best Trial: ", study.best_trial)
-    print("Best Params: ", study.best_params)
-    print("Best Value: ", study.best_value)
-
-    if args.save_trials:
-        df = study.trials_dataframe()
-        df.columns = df.columns.str.replace(r"^(datetime_|params_|user_attrs_)", "", regex=True)
-        df.to_csv(f"{config['model']}_{args.output_file}", sep="\t", index=False)
+    print(ht.params2result[ht.params2str(ht.best_params)])
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    parser.add_argument("params_file", type=str, help="parameters file")
     parser.add_argument("--config_files", type=str, default=None, help="fixed config files")
-    parser.add_argument("--params_file", type=str, default=None, help="parameters file")
-    parser.add_argument("--output_file", type=str, default="hyper_example.result", help="output file")
+    parser.add_argument("--output_path", type=str, default="saved/hyper", help="output file")
     parser.add_argument("--display_file", type=str, default=None, help="visualization file")
-    parser.add_argument("--trials", type=int, default=10, help="Optuna trials number")
-    parser.add_argument("--tool", type=str, default="Optuna", help="{ray, hyperopt, optuna}")
+    parser.add_argument("--max_evals", type=int, default=10, help="max evaluations")
+    tool_action = parser.add_argument(
+        "--tool", type=str, default="optuna", choices=["hyperopt", "ray", "optuna"], help="tuning tool"
+    )
     parser.add_argument(
         "--study_name",
         type=str,
-        default=f"optuna_{datetime.now().strftime('%d_%m_%Y_%H:%M:%S')}",
-        help="optuna study name",
+        default=f"hyper_{datetime.now().strftime('%d_%m_%Y_%H_%M_%S')}",
+        help="Trial study name for hyper tuning.",
     )
-    parser.add_argument("--save_trials", type=bool, default=True, help="whether to save optuna trials in a csv file")
+    hyperopt_algo = parser.add_argument(
+        "--algo",
+        type=str,
+        default=None,
+        help="Algorithm used by the tuner.\n"
+        "For hyperopt it can be: random, tpe, anneal, or exhaustive.\n"
+        "For optuna it identifies sampler and pruner separated by '-'. One of them can be omitted. "
+        "Examples: TPESampler, HyperbandPruner, RandomSampler-MedianPruner.\n"
+        "For ray it identifies searcher and scheduler separated by '-'. One of them can be omitted. "
+        "Examples: async_hyperband, bohb, bohb-pbt_replay. \n"
+        "For more details, please refer to the official website of the corresponding tool.",
+    )
     args, _ = parser.parse_known_args()
 
-    if args.tool == "Hyperopt":
-        hyperopt_tune(args)
-    elif args.tool == "Ray":
-        ray_tune(args)
-    elif args.tool == "Optuna":
-        optuna_tune(args)
-    else:
-        raise ValueError(f"The tool [{args.tool}] should in ['Hyperopt', 'Ray', 'Optuna']")
+    config_file_list = args.config_files.strip().split(" ") if args.config_files else None
+
+    tune(args)


### PR DESCRIPTION
- Removed optuna objective from quickstart
- run_hyper reduced to only handle the argument parser
- HyperTuning class now also receives other parameters, especially `tuner`, which controls which tuner can be used among hyperopt, ray, and optuna.
- Fixed ray not starting. Using `ray.init(adress='auto')` expects a cluster already waiting to listen to the ray process. If used just with `ray.init()` ray is executed in multi-processing in just the machine it has been executed on
- Unified output for all tuner types
- Each tuner type saves a file to store runs already started. If a fixed `study_name` is used instead of the default one, a run can be restored and continued starting from the next parameter combination. The default folder is saved/hyper